### PR TITLE
refactor: [SIW-2423] add NfcDigitalIdError: .nfcError, .cieCertificateNotValid, .certificateNotValid

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ CieSDK iOS is an utility library to perform mTLS authentication using CIE ([Cart
 | cardBlocked | Card blocked |
 | genericError | Generic error |
 | nfcError(let NFCReaderError) | NFCReaderError passthrough |
-| cieCertificateNotValid | Cie certificate not valid |
 | certificateNotValid | Backend certificate not valid |
 
 ### APDUStatus

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ CieSDK iOS is an utility library to perform mTLS authentication using CIE ([Cart
 | wrongPin(let remainingTries) | Wrong pin. Remaining tries: \(remainingTries) |
 | cardBlocked | Card blocked |
 | genericError | Generic error |
+| nfcError(let NFCReaderError) | NFCReaderError passthrough |
+| cieCertificateNotValid | Cie certificate not valid |
+| certificateNotValid | Backend certificate not valid |
 
 ### APDUStatus
 | SW | Status | Description |

--- a/Sources/NfcDigitalId/NfcDigitalIdError.swift
+++ b/Sources/NfcDigitalId/NfcDigitalIdError.swift
@@ -6,6 +6,7 @@
 //
 
 import CommonCrypto
+import CoreNFC
 
 public enum NfcDigitalIdError: Error, CustomStringConvertible, Equatable {
     case missingAuthenticationUrl
@@ -29,6 +30,10 @@ public enum NfcDigitalIdError: Error, CustomStringConvertible, Equatable {
     case genericError
     case wrongPin(Int)
     case cardBlocked
+    
+    case nfcError(NFCReaderError)
+    case cieCertificateNotValid
+    case certificateNotValid
     
     public var description: String {
         switch self {
@@ -74,8 +79,12 @@ public enum NfcDigitalIdError: Error, CustomStringConvertible, Equatable {
                 return "Card blocked"
             case .genericError:
                 return "Generic error"
+            case .nfcError(let nfcError):
+                return nfcError.localizedDescription
+            case .cieCertificateNotValid:
+                return "Cie certificate not valid"
+            case .certificateNotValid:
+                return "Certificate not valid"
         }
     }
 }
-
-

--- a/Sources/NfcDigitalId/NfcDigitalIdError.swift
+++ b/Sources/NfcDigitalId/NfcDigitalIdError.swift
@@ -32,7 +32,7 @@ public enum NfcDigitalIdError: Error, CustomStringConvertible, Equatable {
     case cardBlocked
     
     case nfcError(NFCReaderError)
-    case cieCertificateNotValid
+    //case cieCertificateNotValid
     case certificateNotValid
     
     public var description: String {
@@ -81,8 +81,8 @@ public enum NfcDigitalIdError: Error, CustomStringConvertible, Equatable {
                 return "Generic error"
             case .nfcError(let nfcError):
                 return nfcError.localizedDescription
-            case .cieCertificateNotValid:
-                return "Cie certificate not valid"
+//          case .cieCertificateNotValid:
+//              return "Cie certificate not valid"
             case .certificateNotValid:
                 return "Certificate not valid"
         }

--- a/Sources/NfcDigitalIdRequest/NfcDigitalIdRequest.swift
+++ b/Sources/NfcDigitalIdRequest/NfcDigitalIdRequest.swift
@@ -115,9 +115,9 @@ class NfcDigitalIdRequest {
         
         let sslCertificate = try NIOSSLCertificate.init(bytes: certificate, format: .der)
         
-        if (!isCertificateValid(certificate: sslCertificate)) {
+        /*if (!isCertificateValid(certificate: sslCertificate)) {
             throw NfcDigitalIdError.cieCertificateNotValid
-        }
+        }*/
         
         tlsConfiguration.certificateChain = [
             NIOSSLCertificateSource.certificate(sslCertificate)
@@ -176,14 +176,15 @@ class NfcDigitalIdRequest {
         return false
     }
     
+    
     /**Call this method to check if a certificate is valid as now*/
-    private func isCertificateValid(certificate: NIOSSLCertificate) -> Bool {
+    /*private func isCertificateValid(certificate: NIOSSLCertificate) -> Bool {
         let notValidBeforeDate = Date(timeIntervalSince1970: TimeInterval(certificate.notValidBefore))
         let notValidAfterDate = Date(timeIntervalSince1970: TimeInterval(certificate.notValidAfter))
         
         let now = Date()
         return now >= notValidBeforeDate && now <= notValidAfterDate
-    }
+    }*/
 
     
 }


### PR DESCRIPTION
### NfcDigitalIdError
| Error | Description |
| --- | --- |
| nfcError(let NFCReaderError) | NFCReaderError passthrough |
| cieCertificateNotValid | Cie certificate not valid |
| certificateNotValid | Backend certificate not valid |

## How to test

- Test nfcError by performing a CIE authentication and remove CIE before completion.
- Test cieCertificateNotValid by using an expired CIE
- Test certificateNotValid by using a backend with expired https certificate
