### PR TITLE
refactor: [IOPID-3121] Remove `prepare_command` from `podspec`

### DIFF
--- a/CieSDK.podspec
+++ b/CieSDK.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CieSDK'
-  s.version          = '0.1.10'
+  s.version          = '0.1.11'
   s.summary          = 'A native SDK for reading the Italian EIC (CIE).'
 
 # This description is used to generate tags and improve search results.

--- a/CieSDKSources.podspec
+++ b/CieSDKSources.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CieSDK'
-  s.version          = '0.1.10'
+  s.version          = '0.1.11'
   s.summary          = 'A native SDK for reading the Italian EIC (CIE).'
 
 # This description is used to generate tags and improve search results.

--- a/CieSDKSources.podspec
+++ b/CieSDKSources.podspec
@@ -25,13 +25,14 @@ Pod::Spec.new do |s|
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'PagoPA S.p.A.' => 'ioapptech@pagopa.it' }
+  s.source           = { :git => 'https://git@github.com/pagopa/cie-sdk-ios.git', tag: s.version }
  
-  s.source                  = { :http => "https://github.com/pagopa/cie-sdk-ios/releases/download/" + s.version.to_s + "/CieSDK-" + s.version.to_s + ".xcframework.zip" }
-  s.ios.vendored_frameworks = "CieSDK.xcframework"
-
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '13.0'
 
+  s.prepare_command = './.build.sh'
+
+  s.ios.vendored_frameworks = ".archives/CieSDK.xcframework"
 
 end


### PR DESCRIPTION
## List of changes proposed in this pull request

- Removed `prepare_command` from `podspec`

## How to test

```bash
bundler exec pod spec lint CieSDK.podspec
```

and expect

```bash
CieSDK.podspec passed validation.
```
